### PR TITLE
Route explicit completion through an interactive selector

### DIFF
--- a/docs/kosh.1
+++ b/docs/kosh.1
@@ -1712,6 +1712,16 @@ smart-case and subsequence matches. An empty command position includes
 keywords, builtins, functions, aliases, koshkit utilities, and programs from
 PATH. An exact prefix ranks before a subsequence match.
 .PP
+An explicit Tab prints the candidates below the prompt. When
+.B KOSH_FZF_COMPLETION
+is enabled and more than one candidate remains, the candidates are handed to
+the selector named by
+.B KOSH_FZF_COMPLETION_COMMAND
+and what it prints replaces the token. The editor leaves raw mode while the
+selector owns the terminal, then repaints the prompt. The printed list is kept
+when the selector is cancelled or missing, when one candidate remains, and when
+the session has no controlling terminal.
+.PP
 Completion identifies the command segment at the cursor across quoted
 separators, command substitutions, and here-document bodies. Directory prefixes
 that use quotes, escapes, variables, or tildes retain their typed form. An
@@ -1837,6 +1847,14 @@ The value names the z frecency store. The default is
 .TP
 .B KOSH_CALC_HISTORY
 The value names interactive calc history. The default is ~/.kosh_calc_history.
+.TP
+.BR KOSH_FZF_COMPLETION ", " KOSH_FZF_COMPLETION_COMMAND ", " KOSH_FZF_COMPLETION_OPTS
+A value other than empty or 0 in KOSH_FZF_COMPLETION routes the candidates of an
+explicit Tab through an interactive selector. KOSH_FZF_COMPLETION_COMMAND names
+that program and defaults to
+.BR fzf .
+KOSH_FZF_COMPLETION_OPTS supplies further options, split on blanks with no
+expansion, and they follow the built-in ones so they win.
 .TP
 .BR ENV ", " BASH_ENV
 These variables select startup files under the conditions in

--- a/src/EvalCompletionBridge.cpp
+++ b/src/EvalCompletionBridge.cpp
@@ -148,8 +148,18 @@ fn EvalContext::run_completion_function(StringView function_name,
 
   /* A completion function that errors must not abort the prompt, so any error
      is swallowed and a stray break or return is consumed. */
+  let was_interrupted = false;
   try {
     body->evaluate(*this);
+  } catch (const InterruptErrorWithLocation &) {
+    /* The throw already consumed the interrupt request on its way out, so it is
+       raised again for the caller. Without it the editor would see a settled
+       flag and offer whatever the function had filled in before the user asked
+       it to stop. */
+    was_interrupted = true;
+    os::INTERRUPT_REQUESTED = 1;
+    LOG(Debug, "completion function '%.*s' was interrupted",
+        static_cast<int>(function_name.length), function_name.data);
   } catch (const ErrorBase &error) {
     LOG(Debug, "completion function '%.*s' threw: %s",
         static_cast<int>(function_name.length), function_name.data,
@@ -162,7 +172,7 @@ fn EvalContext::run_completion_function(StringView function_name,
 
   let result = ArrayList<String>{heap_allocator()};
   if (const ArrayList<String> *reply = lookup_indexed_array("COMPREPLY");
-      reply != nullptr)
+      !was_interrupted && reply != nullptr)
   {
     result.reserve(reply->count());
     for (let const &entry : *reply)

--- a/src/Toiletline.cpp
+++ b/src/Toiletline.cpp
@@ -19,6 +19,7 @@
 #include "Debug.hpp"
 #include "Errors.hpp"
 #include "Eval.hpp"
+#include "ExecContext.hpp"
 #include "Path.hpp"
 #include "Platform.hpp"
 #include "Trace.hpp"
@@ -132,6 +133,228 @@ koshka::ArrayList<const char *> COMPLETION_DESCRIPTION_POINTERS{
     koshka::heap_allocator()};
 koshka::completion::completion_result *COMPLETION_RESULT = nullptr;
 
+/* An explicit tab normally prints the candidates as a static list. When
+   KOSH_FZF_COMPLETION holds anything other than an empty value or 0, the same
+   candidates are handed to a filtering program instead, and what it prints
+   replaces them. The engine, the replaced token span, and the quoting are
+   untouched, so only the presentation moves. Every failure below leaves the
+   result alone, so the static list still appears. */
+constexpr koshka::StringView SELECTOR_ENABLE_VARIABLE{"KOSH_FZF_COMPLETION"};
+constexpr koshka::StringView SELECTOR_COMMAND_VARIABLE{
+    "KOSH_FZF_COMPLETION_COMMAND"};
+constexpr koshka::StringView SELECTOR_OPTIONS_VARIABLE{
+    "KOSH_FZF_COMPLETION_OPTS"};
+
+fn selector_command_name(koshka::EvalContext &context) throws
+    -> koshka::Maybe<koshka::String>
+{
+  let const enabled = context.get_variable_value(SELECTOR_ENABLE_VARIABLE);
+  if (!enabled.has_value() || enabled->is_empty() ||
+      enabled->view() == koshka::StringView{"0"})
+  {
+    return koshka::None;
+  }
+
+  if (let const configured =
+          context.get_variable_value(SELECTOR_COMMAND_VARIABLE);
+      configured.has_value() && !configured->is_empty())
+  {
+    return koshka::String{configured->view()};
+  }
+  return koshka::String{"fzf"};
+}
+
+/* Records are NUL separated in both directions, so a candidate carrying a
+   newline still travels as one field. A description rides after a tab, which
+   makes it searchable while never reaching the line. */
+fn build_selector_input(const koshka::completion::completion_result &result)
+    throws -> koshka::String
+{
+  let input = koshka::String{koshka::heap_allocator()};
+  let const has_descriptions = result.descriptions.count() > 0;
+  for (let const &candidate : result.candidates) {
+    input.append(candidate.view());
+    if (has_descriptions) {
+      if (const koshka::String *description =
+              result.descriptions.find(candidate.view());
+          description != nullptr && !description->is_empty())
+      {
+        input.push('\t');
+        input.append(description->view());
+      }
+    }
+    input.push('\0');
+  }
+  return input;
+}
+
+fn build_selector_args(koshka::EvalContext &context,
+                       const koshka::Path &program) throws
+    -> koshka::ArrayList<koshka::String>
+{
+  let args = koshka::ArrayList<koshka::String>{koshka::heap_allocator()};
+  args.push(koshka::String{program.text().view()});
+  args.push(koshka::String{"--read0"});
+  args.push(koshka::String{"--print0"});
+  args.push(koshka::String{"--multi"});
+  args.push(koshka::String{"--layout=reverse"});
+  args.push(koshka::String{"--height=~40%"});
+  args.push(koshka::String{"--min-height=3"});
+
+  /* The user's own options come last so they win over the defaults above. The
+     value is split on blanks with no expansion, since a completion keystroke
+     must never run a substitution. */
+  if (let const options = context.get_variable_value(SELECTOR_OPTIONS_VARIABLE);
+      options.has_value() && !options->is_empty())
+  {
+    for (let const &option :
+         context.expand_wordlist_to_fields(options->view(), false))
+      args.push(koshka::String{option.view()});
+  }
+  return args;
+}
+
+/* The selected records, with each description stripped back off. */
+fn parse_selector_reply(koshka::StringView reply) throws
+    -> koshka::ArrayList<koshka::String>
+{
+  let selected = koshka::ArrayList<koshka::String>{koshka::heap_allocator()};
+  usize start = 0;
+  for (usize i = 0; i <= reply.length; i++) {
+    if (i != reply.length && reply[i] != '\0') continue;
+    if (i > start) {
+      let record = reply.substring_of_length(start, i - start);
+      if (let const tab = record.find_character('\t'); tab.has_value())
+        record = record.substring_of_length(0, *tab);
+      /* fzf writes a trailing newline of its own under some option sets. */
+      while (!record.is_empty() && record[record.length - 1] == '\n')
+        record = record.substring_of_length(0, record.length - 1);
+      if (!record.is_empty()) selected.push(koshka::String{record});
+    }
+    start = i + 1;
+  }
+  return selected;
+}
+
+enum class selector_outcome : u8
+{
+  /* The selector did not run, so the printed list still answers the key. */
+  NotRun,
+  /* The result now holds the replacement the user chose. */
+  Selected,
+  /* The user dismissed the selector, so the key does nothing at all. Printing
+     the list here would dump every candidate over the screen the user just
+     chose to keep. */
+  Dismissed,
+};
+
+fn run_completion_selector(koshka::EvalContext &context,
+                           koshka::completion::completion_result &result) throws
+    -> selector_outcome
+{
+  if (result.candidates.count() < 2) return selector_outcome::NotRun;
+  if (!::itl_g_is_active) return selector_outcome::NotRun;
+  if (!koshka::os::shell_has_controlling_terminal())
+    return selector_outcome::NotRun;
+
+  let const command_name = selector_command_name(context);
+  if (!command_name.has_value()) return selector_outcome::NotRun;
+
+  let const resolved = context.get_program_resolver().search(
+      command_name->view(), koshka::ProgramResolver::SearchMode::First,
+      koshka::ProgramResolver::Requirement::Execution,
+      koshka::ProgramResolver::CachePolicy::ReadOnly);
+  if (resolved.is_empty()) return selector_outcome::NotRun;
+
+  let const input = build_selector_input(result);
+  let const input_fd = koshka::os::write_to_temp_file(input.view());
+  if (!input_fd.has_value()) return selector_outcome::NotRun;
+
+  let const output_pipe = koshka::os::make_pipe();
+  if (!output_pipe.has_value()) {
+    koshka::os::close_fd(*input_fd);
+    return selector_outcome::NotRun;
+  }
+
+  /* execute_program owns both descriptors it is handed and closes them on every
+     path, so only the read end is released here. */
+  bool are_child_descriptors_owned = true;
+  bool is_read_end_open = true;
+  defer
+  {
+    if (are_child_descriptors_owned) {
+      koshka::os::close_fd(*input_fd);
+      koshka::os::close_fd(output_pipe->out);
+    }
+    if (is_read_end_open) koshka::os::close_fd(output_pipe->in);
+  };
+
+  let arg_locations =
+      koshka::ArrayList<koshka::SourceLocation>{koshka::heap_allocator()};
+  let selector = koshka::ExecContext::from_resolved(
+      koshka::SourceLocation{},
+      koshka::ResolvedCommand::from_program(koshka::Path{resolved[0].text()}),
+      build_selector_args(context, resolved[0]), steal(arg_locations));
+  selector.in_fd = *input_fd;
+  selector.out_fd = output_pipe->out;
+
+  koshka::flush();
+  if (::tl_begin_external_screen() != TL_SUCCESS)
+    return selector_outcome::NotRun;
+  bool is_editor_suspended = true;
+  defer
+  {
+    if (is_editor_suspended) unused(::tl_end_external_screen());
+  };
+
+  are_child_descriptors_owned = false;
+  let const child = koshka::os::execute_program(
+      selector, koshka::os::script_fallback_policy::Reject,
+      koshka::os::process_group_mode::Inherit, koshka::StringView{},
+      koshka::os::terminal_handoff::BeforeStart);
+
+  let const captured =
+      koshka::os::read_fd_to_string(output_pipe->in, koshka::heap_allocator());
+  koshka::os::close_fd(output_pipe->in);
+  is_read_end_open = false;
+
+  let const status = koshka::os::wait_and_monitor_process(child);
+  koshka::os::reclaim_controlling_terminal();
+  /* A cancelled picker exits nonzero, and its own SIGINT must not abort the
+     next command the way an interrupted prompt would. */
+  koshka::os::INTERRUPT_REQUESTED = 0;
+
+  is_editor_suspended = false;
+  if (::tl_end_external_screen() != TL_SUCCESS) return selector_outcome::NotRun;
+
+  /* A picker reports 0 for a selection, 1 when nothing matched, and 130 when it
+     was dismissed. Only a status it never uses for either, such as a failure to
+     start, falls back to the printed list. */
+  if (status != 0)
+    return status == 1 || status == 130 ? selector_outcome::Dismissed
+                                        : selector_outcome::NotRun;
+  if (!captured.has_value()) return selector_outcome::NotRun;
+
+  let selected = parse_selector_reply(captured->view());
+  if (selected.is_empty()) return selector_outcome::Dismissed;
+
+  /* Several picks join into one replacement, the same shape the inline glob
+     expansion produces, so the token is rewritten once. */
+  let replacement = koshka::String{koshka::heap_allocator()};
+  for (usize i = 0; i < selected.count(); i++) {
+    if (i > 0) replacement.push(' ');
+    replacement.append(selected[i].view());
+  }
+
+  result.candidates.clear();
+  result.descriptions.clear();
+  result.longest_common_prefix =
+      koshka::String{koshka::heap_allocator(), replacement.view()};
+  result.candidates.push(steal(replacement));
+  result.candidate_count = 1;
+  return selector_outcome::Selected;
+}
+
 /* Toiletline edits in codepoints while the completion engine works in bytes. */
 fn kosh_completion_callback(const char *buffer, size_t cursor,
                             tl_completion *out, int for_listing) -> int
@@ -156,6 +379,21 @@ fn kosh_completion_callback(const char *buffer, size_t cursor,
         COMPLETION_CONTEXT->get_program_resolver().end_explicit_completion();
     };
 
+    /* A completion spec can shell out, and a command talking to an unreachable
+       host blocks until its own timeout. Raw mode swallows the interrupt key as
+       an ordinary byte, so it is handed back to the terminal for the length of
+       the completion and reaches that command as SIGINT the way it would at a
+       prompt. The ghost path runs no spec, so it is left alone. */
+    let const are_signal_keys_enabled =
+        is_explicit_completion && ::tl_set_signal_keys(1) == TL_SUCCESS;
+    defer
+    {
+      if (are_signal_keys_enabled) unused(::tl_set_signal_keys(0));
+      /* An interrupt belongs to the abandoned completion, not to whatever the
+         user types next. */
+      koshka::os::INTERRUPT_REQUESTED = 0;
+    };
+
     const usize byte_length = std::strlen(buffer);
     let line = koshka::StringView{buffer, byte_length};
 
@@ -178,6 +416,19 @@ fn kosh_completion_callback(const char *buffer, size_t cursor,
     DEBUG_COMPLETION_MATERIALIZED_COUNT += result.materialized_candidate_count;
 #endif
     koshka::arm_message_leading_newline(false);
+
+    /* An abandoned completion offers nothing, so the key leaves the line as it
+       was rather than acting on whatever the interrupted spec had produced. */
+    if (koshka::os::INTERRUPT_REQUESTED) return 0;
+
+    /* An explicit tab may route the candidates through a filtering picker
+       first. The ghost never does, since it draws no list and must not fork. */
+    if (is_explicit_completion &&
+        run_completion_selector(*COMPLETION_CONTEXT, *COMPLETION_RESULT) ==
+            selector_outcome::Dismissed)
+    {
+      return 0;
+    }
 
     if (result.candidate_count == 0) return 0;
 

--- a/src/UtilsExecution.cpp
+++ b/src/UtilsExecution.cpp
@@ -244,6 +244,15 @@ fn execute_context(ExecContext &&ec, EvalContext &cxt,
                                             os::process_id_of(p));
     cxt.notify_stopped_job(id, command.view());
   }
+  /* A foreground child owns the terminal, so an interrupt reaches it alone and
+     the shell reads only its status. That is right at a prompt, where the next
+     command is the user's own, but a completion spec has no prompt behind it,
+     so its remaining commands would run against a half-finished answer and
+     offer it as if nothing had happened. The interrupt is therefore raised
+     here, which unwinds the spec and turns the key into a cancelled
+     completion. */
+  if (foreground_status == 130 && cxt.is_completion_function_running())
+    os::INTERRUPT_REQUESTED = 1;
   return foreground_status;
 }
 

--- a/test/interactive/AGENTS.md
+++ b/test/interactive/AGENTS.md
@@ -10,6 +10,8 @@ available.
 `cat_syntax_highlighting.py` checks terminal syntax colors for koshkit cat.
 `format_syntax_highlighting.py` checks terminal syntax colors for formatted
 source.
+`fzf_completion.py` checks the interactive completion selector against a stub,
+so it needs no fzf installed.
 `long_warning_window.py` checks clipped diagnostics and caret alignment.
 `mimic_terminal_handoff.py` checks foreground handoff and prompt recovery.
 `underline_term_support.py` checks terminal underline capability handling.

--- a/test/interactive/fzf_completion.py
+++ b/test/interactive/fzf_completion.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""An explicit tab can route its candidates through an interactive selector.
+
+The selector is stubbed rather than run for real, so the suite needs no fzf
+installed and stays deterministic. The stub reads the NUL separated records the
+shell writes, records them, and echoes back the ones it was told to pick, which
+is the same subset contract fzf has.
+"""
+
+import fcntl
+import os
+import pty
+import select
+import signal
+import struct
+import sys
+import tempfile
+import termios
+import time
+
+# Each scenario runs from the candidate tree, so the binary is resolved before
+# any directory change.
+binary = os.path.abspath(sys.argv[1])
+
+SELECTOR_SOURCE = """#!/usr/bin/env python3
+import os
+import sys
+
+records = [record for record in sys.stdin.buffer.read().split(b"\\0") if record]
+
+log_path = os.environ.get("STUB_LOG")
+if log_path:
+    with open(log_path, "ab") as log:
+        log.write(b"ran\\n")
+        for record in records:
+            log.write(b"record " + record + b"\\n")
+
+if os.environ.get("STUB_CANCEL"):
+    sys.exit(130)
+
+picks = os.environ.get("STUB_PICK", "1").split()
+for pick in picks:
+    sys.stdout.buffer.write(records[int(pick) - 1] + b"\\0")
+"""
+
+
+def read_until_idle(master, timeout, required_output=None):
+    output = b""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([master], [], [], 0.1)
+        if master not in readable:
+            if output and (required_output is None or required_output in output):
+                break
+            continue
+        try:
+            chunk = os.read(master, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        output += chunk
+    return output
+
+
+def run_interrupt_scenario(directory):
+    """Tab into a spec that never finishes, then interrupt it.
+
+    A real one is a cloud tool waiting on an unreachable endpoint. Raw mode
+    normally turns the interrupt key into an ordinary byte, so without the
+    handoff the key would queue as input and the prompt would stay stuck.
+    """
+    pid, master = pty.fork()
+    if pid == 0:
+        fcntl.ioctl(1, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 120, 0, 0))
+        os.environ["TERM"] = "xterm-256color"
+        os.environ["HOME"] = directory
+        os.environ["KOSH_HISTORY"] = os.path.join(directory, "history")
+        os.environ.pop("KOSH_FZF_COMPLETION", None)
+        os.chdir(os.path.join(directory, "tree"))
+        os.execv(binary, [binary, "--norc", "--no-diagnostics"])
+
+    read_until_idle(master, 3)
+    os.write(master, b"_stall() { sleep 60; COMPREPLY=(late); }\n")
+    read_until_idle(master, 1)
+    os.write(master, b"complete -F _stall stallcmd\n")
+    read_until_idle(master, 1)
+    os.write(master, b"stallcmd ")
+    read_until_idle(master, 1)
+
+    os.write(master, b"\t")
+    read_until_idle(master, 2)
+
+    started = time.monotonic()
+    os.write(master, b"\x03")
+    output = read_until_idle(master, 8, b"MARKER-BACK")
+    os.write(master, b"printf 'MARKER-BACK\\n'\nexit\n")
+    output += read_until_idle(master, 3)
+    elapsed = time.monotonic() - started
+    os.close(master)
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        waited, _ = os.waitpid(pid, os.WNOHANG)
+        if waited == pid:
+            break
+        time.sleep(0.02)
+    else:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+
+    return output, elapsed
+
+
+def run_scenario(directory, selector, environment, typed):
+    """Type the words, press tab, submit, and return the transcript and log."""
+    log_path = os.path.join(directory, "selector-log")
+    if os.path.exists(log_path):
+        os.remove(log_path)
+
+    pid, master = pty.fork()
+    if pid == 0:
+        fcntl.ioctl(1, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 120, 0, 0))
+        os.environ["TERM"] = "xterm-256color"
+        os.environ["HOME"] = directory
+        os.environ["KOSH_HISTORY"] = os.path.join(directory, "history")
+        os.environ["STUB_LOG"] = log_path
+        os.environ["KOSH_FZF_COMPLETION_COMMAND"] = selector
+        os.environ.pop("KOSH_FZF_COMPLETION", None)
+        os.environ.pop("STUB_CANCEL", None)
+        os.environ.pop("STUB_PICK", None)
+        os.environ.update(environment)
+        os.chdir(os.path.join(directory, "tree"))
+        os.execv(binary, [binary, "--norc", "--no-diagnostics"])
+
+    read_until_idle(master, 3)
+    os.write(master, typed.encode())
+    read_until_idle(master, 1)
+    os.write(master, b"\t")
+    read_until_idle(master, 3)
+    os.write(master, b"\n")
+    output = read_until_idle(master, 2, b"MARKER-END")
+    os.write(master, b"printf 'MARKER-END\\n'\nexit\n")
+    output += read_until_idle(master, 2)
+    os.close(master)
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        waited, _ = os.waitpid(pid, os.WNOHANG)
+        if waited == pid:
+            break
+        time.sleep(0.02)
+    else:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+
+    log = b""
+    if os.path.exists(log_path):
+        with open(log_path, "rb") as handle:
+            log = handle.read()
+    return output, log
+
+
+def main():
+    with tempfile.TemporaryDirectory() as directory:
+        tree = os.path.join(directory, "tree")
+        os.mkdir(tree)
+        for name in ("alpha-one", "alpha-two", "alpha-three", "gamma-solo"):
+            open(os.path.join(tree, name), "w").close()
+        open(os.path.join(tree, "beta only"), "w").close()
+        open(os.path.join(tree, "beta two"), "w").close()
+
+        selector = os.path.join(directory, "selector")
+        with open(selector, "w") as handle:
+            handle.write(SELECTOR_SOURCE)
+        os.chmod(selector, 0o755)
+
+        enabled = {"KOSH_FZF_COMPLETION": "1"}
+        typed = "printf '<%s>\\n' alpha"
+
+        picked, picked_log = run_scenario(
+            directory, selector, {**enabled, "STUB_PICK": "3"}, typed
+        )
+        selector_saw_every_candidate = (
+            b"record alpha-one" in picked_log
+            and b"record alpha-two" in picked_log
+            and b"record alpha-three" in picked_log
+        )
+        pick_replaced_the_token = b"<alpha-two>" in picked
+
+        multi, _ = run_scenario(
+            directory, selector, {**enabled, "STUB_PICK": "1 2"}, typed
+        )
+        several_picks_are_joined = (
+            b"<alpha-one>" in multi and b"<alpha-three>" in multi
+        )
+
+        cancelled, cancelled_log = run_scenario(
+            directory, selector, {**enabled, "STUB_CANCEL": "1"}, typed
+        )
+        cancel_ran_the_selector = b"ran\n" in cancelled_log
+        cancel_leaves_the_line_alone = b"<alpha>" in cancelled
+        # Falling back to the printed list here would dump every candidate over
+        # the screen the user just dismissed.
+        cancel_prints_no_list = (
+            b"alpha-one" not in cancelled and b"alpha-three" not in cancelled
+        )
+
+        disabled, disabled_log = run_scenario(directory, selector, {}, typed)
+        disabled_skips_the_selector = disabled_log == b""
+        disabled_keeps_the_static_completion = b"<alpha->" in disabled
+
+        lone, lone_log = run_scenario(
+            directory,
+            selector,
+            {**enabled, "STUB_PICK": "1"},
+            "printf '<%s>\\n' gamma",
+        )
+        one_candidate_skips_the_selector = lone_log == b""
+        one_candidate_is_inserted = b"<gamma-solo>" in lone
+
+        quoted, quoted_log = run_scenario(
+            directory,
+            selector,
+            {**enabled, "STUB_PICK": "1"},
+            "printf '<%s>\\n' beta",
+        )
+        quoting_survives_the_selector = (
+            b"record 'beta only'" in quoted_log and b"<beta only>" in quoted
+        )
+
+        prompt_stays_usable = b"MARKER-END" in picked
+
+        interrupted, interrupt_seconds = run_interrupt_scenario(directory)
+        interrupt_frees_the_prompt = b"MARKER-BACK" in interrupted
+        interrupt_is_prompt = interrupt_seconds < 20
+        interrupt_drops_the_candidates = b"late" not in interrupted
+
+        results = {
+            "SELECTOR_SAW_EVERY_CANDIDATE": selector_saw_every_candidate,
+            "PICK_REPLACED_THE_TOKEN": pick_replaced_the_token,
+            "SEVERAL_PICKS_ARE_JOINED": several_picks_are_joined,
+            "CANCEL_RAN_THE_SELECTOR": cancel_ran_the_selector,
+            "CANCEL_LEAVES_THE_LINE_ALONE": cancel_leaves_the_line_alone,
+            "CANCEL_PRINTS_NO_LIST": cancel_prints_no_list,
+            "DISABLED_SKIPS_THE_SELECTOR": disabled_skips_the_selector,
+            "DISABLED_KEEPS_THE_STATIC_COMPLETION": (
+                disabled_keeps_the_static_completion
+            ),
+            "ONE_CANDIDATE_SKIPS_THE_SELECTOR": one_candidate_skips_the_selector,
+            "ONE_CANDIDATE_IS_INSERTED": one_candidate_is_inserted,
+            "QUOTING_SURVIVES_THE_SELECTOR": quoting_survives_the_selector,
+            "PROMPT_STAYS_USABLE": prompt_stays_usable,
+            "INTERRUPT_FREES_THE_PROMPT": interrupt_frees_the_prompt,
+            "INTERRUPT_IS_PROMPT": interrupt_is_prompt,
+            "INTERRUPT_DROPS_THE_CANDIDATES": interrupt_drops_the_candidates,
+        }
+
+    passed = all(results.values())
+    for name, value in results.items():
+        print(f"{name}: {value}")
+    print("FZF_COMPLETION:", passed)
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
An explicit Tab prints its candidates and leaves the user to retype. This routes
the same candidates through an interactive selector, the way fzf-tab does under
zsh, when `KOSH_FZF_COMPLETION` names a value other than empty or `0`.

Depends on toiletbril/toiletline#3, which adds the external screen API this uses.
The submodule pointer is left untouched here.

`KOSH_FZF_COMPLETION_COMMAND` names the program and defaults to `fzf`.
`KOSH_FZF_COMPLETION_OPTS` supplies further options, split on blanks with no
expansion, and they follow the built-in ones so a user setting wins. Candidates
reach the child as NUL separated records with the description after a tab, and
only the part before that tab is inserted.

The printed list is kept when the selector is missing, when it cannot be
resolved, when one candidate remains, and when the session holds no controlling
terminal. A dismissed selector leaves the line as it was typed and prints
nothing, since falling back to the list would cover the screen the user just
cleared.

The editor hands the terminal to the child and reclaims it afterward. ISIG is
restored for the length of a completion, so a spec that talks to an unreachable
host answers the interrupt key. A foreground child killed by that key inside a
completion spec now raises the interrupt, and `run_completion_function` drops
`COMPREPLY` on the way out, so an interrupted spec offers nothing.

`test/interactive/fzf_completion.py` drives the whole path through a pseudo
terminal against a stub selector, so the suite needs no fzf installed. It covers
the records the selector receives, single and multiple picks, dismissal, the
disabled setting, the lone candidate, quoting, and the interrupt.

Measured against `make MODE=rel` on macOS 26.4.1 arm64. The 15 assertions pass
and the rest of the suite is unchanged.
